### PR TITLE
Add macros for linear and last-observed-value-forward interpolations

### DIFF
--- a/lib/timescale/hyperfunctions.ex
+++ b/lib/timescale/hyperfunctions.ex
@@ -111,4 +111,26 @@ defmodule Timescale.Hyperfunctions do
       fragment("time_bucket_gapfill(?, ?)", unquote(time_bucket), unquote(field))
     end
   end
+
+  @doc """
+  Fills in missing values by linear interpolation.
+
+  [Documentation](https://docs.timescale.com/api/latest/hyperfunctions/gapfilling/time_bucket_gapfill/#interpolate)
+  """
+  defmacro interpolate(field) do
+    quote do
+      fragment("interpolate(?)", unquote(field))
+    end
+  end
+
+  @doc """
+  Fill in missing values by carrying the last observed value forward.
+
+  [Documentation](https://docs.timescale.com/api/latest/hyperfunctions/gapfilling/time_bucket_gapfill/#locf)
+  """
+  defmacro locf(field) do
+    quote do
+      fragment("locf(?)", unquote(field))
+    end
+  end
 end

--- a/test/timescale/hyperfunction_test.exs
+++ b/test/timescale/hyperfunction_test.exs
@@ -64,4 +64,18 @@ defmodule Timescale.HyperfunctionTest do
       ~s[SELECT time_bucket('5 minutes', t0."timestamp", offset => '2.5 minutes', origin => '1900-01-01') FROM "test_hypertable" AS t0]
     )
   end
+
+  test "interpolate/1 generates a value query" do
+    assert_sql(
+      from(t in Table, select: interpolate(t.field)),
+      ~s[SELECT interpolate(t0."field") FROM "test_hypertable" AS t0]
+    )
+  end
+
+  test "locf/1 generates a value query" do
+    assert_sql(
+      from(t in Table, select: locf(t.field)),
+      ~s[SELECT locf(t0."field") FROM "test_hypertable" AS t0]
+    )
+  end
 end


### PR DESCRIPTION
👋 Please forgive this somewhat hastily put together pull request. I glanced briefly at your open issues, but I can't say for certain this hasn't already been addressed in some other way. Also, I should warn that I'm very new to timescale, so forgive me if I'm missing something obvious.

# Problem
Timescale provides a couple functions that inform how missing values are interpolated, but this library does not provide macros for these functions.

# Solution
Implement macros for `interpolate` (linear filling) and `locf` (last observed value forward).